### PR TITLE
transcode data without copying

### DIFF
--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -182,6 +182,15 @@ function copymarked(buf::Buffer)
     return buf.data[buf.markpos:buf.marginpos-1]
 end
 
+# Take the ownership of the marked data.
+function takemarked!(buf::Buffer)
+    @assert buf.markpos > 0
+    sz = buf.marginpos - buf.markpos
+    copy!(buf.data, 1, buf.data, buf.markpos, sz)
+    initbuffer!(buf)
+    return resize!(buf.data, sz)
+end
+
 # Read as much data as possbile from `input` to the margin of `output`.
 # This function will not block if `input` has buffered data.
 function readdata!(input::IO, output::Buffer)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -327,7 +327,7 @@ function Base.transcode(codec::Codec, data::Vector{UInt8})
     mark!(buffer2)
     stream = TranscodingStream(codec, DevNull, State(Buffer(data), buffer2))
     write(stream, TOKEN_END)
-    transcoded = copymarked(buffer2)
+    transcoded = takemarked!(buffer2)
     changestate!(stream, :idle)
     return transcoded
 end

--- a/src/testtools.jl
+++ b/src/testtools.jl
@@ -26,9 +26,11 @@ end
 
 function test_roundtrip_transcode(encode, decode)
     srand(12345)
+    encoder = encode()
+    decoder = decode()
     for n in vcat(0:30, sort!(rand(500:100_000, 30))), alpha in (0x00:0xff, 0x00:0x0f)
         data = rand(alpha, n)
-        Base.Test.@test hash(transcode(decode(), transcode(encode(), data))) == hash(data)
+        Base.Test.@test hash(transcode(decoder, transcode(encoder, data))) == hash(data)
     end
 end
 


### PR DESCRIPTION
This is pointed in https://github.com/bicycle1885/TranscodingStreams.jl/issues/8#issuecomment-323621477. This patch reduces the memory allocation from 490.31 KiB to 280.61 KiB.

```
--- Base64 Decoder ---
BenchmarkTools.Trial:
  memory estimate:  280.61 KiB
  allocs estimate:  17
  --------------
  minimum time:     354.832 μs (0.00% GC)
  median time:      458.672 μs (0.00% GC)
  mean time:        485.005 μs (4.25% GC)
  maximum time:     2.764 ms (71.20% GC)
  --------------
  samples:          2055
  evals/sample:     1

```