### PR TITLE
prohibit stream from changing read/write mode

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -466,6 +466,8 @@ function changestate!(stream::TranscodingStream, newstate::Symbol)
     state = stream.state.state
     buffer1 = stream.state.buffer1
     buffer2 = stream.state.buffer2
+    transition_error() =
+        throw(ArgumentError("cannot change the mode from $(state) to $(newstate)"))
     if state == newstate
         # state does not change
         return
@@ -488,9 +490,7 @@ function changestate!(stream::TranscodingStream, newstate::Symbol)
             stream.state.state = newstate
             return
         elseif newstate == :write
-            changestate!(stream, :idle)
-            changestate!(stream, :write)
-            return
+            transition_error()
         elseif newstate == :close
             changestate!(stream, :idle)
             changestate!(stream, :close)
@@ -504,9 +504,7 @@ function changestate!(stream::TranscodingStream, newstate::Symbol)
             stream.state.state = newstate
             return
         elseif newstate == :read
-            changestate!(stream, :idle)
-            changestate!(stream, :read)
-            return
+            transition_error()
         elseif newstate == :close
             changestate!(stream, :idle)
             changestate!(stream, :close)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,14 +57,6 @@ end
     @test_throws EOFError unsafe_read(stream, pointer(Vector{UInt8}(3)), 3)
     close(stream)
 
-    # switch write => read
-    buf = IOBuffer(b"foobar", true, true)
-    stream = TranscodingStream(Identity(), buf)
-    @test write(stream, b"xyz") == 3
-    @test read(stream, 3) == b"bar"
-    @test take!(buf) == b"xyzbar"
-    close(stream)
-
     sink = IOBuffer()
     stream = TranscodingStream(Identity(), sink)
     @test write(stream, "foo") === 3
@@ -192,6 +184,20 @@ end
     TranscodingStreams.test_roundtrip_read(NoopStream, NoopStream)
     TranscodingStreams.test_roundtrip_write(NoopStream, NoopStream)
     TranscodingStreams.test_roundtrip_lines(NoopStream, NoopStream)
+
+    # switch write => read
+    stream = NoopStream(IOBuffer(b"foobar", true, true))
+    @test_throws ArgumentError begin
+        write(stream, b"xyz")
+        read(stream, 3)
+    end
+
+    # switch read => write
+    stream = NoopStream(IOBuffer(b"foobar", true, true))
+    @test_throws ArgumentError begin
+        read(stream, 3)
+        write(stream, b"xyz")
+    end
 end
 
 # This does not implement necessary interface methods.


### PR DESCRIPTION
Changing read/write mode does not work as expected in most cases, so it would be better to forbid it for now. This is actually a breaking change but I guess nobody depends on this behavior.