### PR TITLE
Change mode from idle to read when eof is called

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -376,6 +376,12 @@ end
 # Write Functions
 # ---------------
 
+# Write nothing.
+function Base.write(stream::TranscodingStream)
+    changemode!(stream, :write)
+    return 0
+end
+
 function Base.write(stream::TranscodingStream, b::UInt8)
     changemode!(stream, :write)
     if marginsize(stream.state.buffer1) == 0 && flushbuffer(stream) == 0

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -159,8 +159,8 @@ end
 function Base.eof(stream::TranscodingStream)
     mode = stream.state.mode
     if mode == :idle
-        # FIXME: This is not true when empty data are compressed.
-        return eof(stream.stream)
+        changemode!(stream, :read)
+        return eof(stream)
     elseif mode == :read
         return buffersize(stream.state.buffer1) == 0 && fillbuffer(stream) == 0
     elseif mode == :write

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -319,7 +319,6 @@ end
     close(stream)
 
     stream = NoopStream(IOBuffer(""))
-    @test eof(stream)  # idle
     unsafe_write(stream, C_NULL, 0)
     @test eof(stream)  # write
     close(stream)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,6 +232,12 @@ end
     @test TranscodingStreams.stats(stream).out === Int64(6)
     close(stream)
 
+    stream = TranscodingStream(Noop(), IOBuffer())
+    @test stream.state.mode == :idle
+    @test write(stream) == 0
+    @test stream.state.mode == :write
+    close(stream)
+
     stream = NoopStream(IOBuffer("foobar"))
     @test nb_available(stream) === 0
     @test readavailable(stream) == b""


### PR DESCRIPTION
This will change the behavior as follows.

master:
```
julia> using CodecZlib

julia> pipe, proc = open(pipeline(`echo -n`, `gzip`));

julia> stream = GzipDecompressionStream(pipe)
TranscodingStreams.TranscodingStream{CodecZlib.GzipDecompression,Pipe}(<mode=idle>)

julia> eof(stream)
false

```

this branch:
```
julia> using CodecZlib

julia> pipe, proc = open(pipeline(`echo -n`, `gzip`));

julia> stream = GzipDecompressionStream(pipe)
TranscodingStreams.TranscodingStream{CodecZlib.GzipDecompression,Pipe}(<mode=idle>)

julia> eof(stream)
true

```