### PR TITLE
testtools.jl - deprecated syntax

### DIFF
--- a/src/testtools.jl
+++ b/src/testtools.jl
@@ -1,7 +1,7 @@
 # Test Tools
 # ==========
 
-using Test: Test
+using Test.Test
 using Random: seed!, randstring
 
 TEST_RANDOM_SEED = 12345


### PR DESCRIPTION
I came across this warning when upgrading through Julia v0.7:
```
Julia-0.7.0> using TranscodingStreams
[ Info: Precompiling TranscodingStreams [3bb67fe8-82b1-5028-8e26-92a6c54297fa]
┌ Warning: `using A: B` will only be allowed for single bindings, not modules. Use `using A.B` instead
│   caller = ip:0x0
└ @ Core :-1
```
It comes from the deprecated `using Test: Test` in `testtools.jl`
Changed to `using Test.Test`

I made the most direct upgrade of syntax, but why not just `import Test`?