### PR TITLE
fix transcode's performance problem

### DIFF
--- a/src/transcode.jl
+++ b/src/transcode.jl
@@ -77,11 +77,53 @@ julia> String(decompressed)
 ```
 """
 function Base.transcode(codec::Codec, data::ByteData)
-    # Add `minoutsize` because `transcode` will be called at least two times.
-    buffer2 = Buffer(
-        expectedsize(codec, Memory(data)) + minoutsize(codec, Memory(C_NULL, 0)))
-    mark!(buffer2)
-    stream = TranscodingStream(codec, devnull, State(Buffer(data), buffer2); initialized=true)
-    write(stream, TOKEN_END)
-    return takemarked!(buffer2)
+    input = Buffer(data)
+    output = Buffer(initial_output_size(codec, Memory(data)))
+    error = Error()
+    code = startproc(codec, :write, error)
+    if codec === :error
+        @goto error
+    end
+    while code !== :end || buffersize(input) > 0
+        makemargin!(output, minoutsize(codec, buffermem(input)))
+        Δin, Δout, code = process(codec, buffermem(input), marginmem(output), error)
+        @debug(
+            "called process()",
+            code = code,
+            input_size = buffersize(input),
+            output_size = marginsize(output),
+            input_delta = Δin,
+            output_delta = Δout,
+        )
+        consumed!(input, Δin)
+        supplied!(output, Δout)
+        if code === :error
+            @goto error
+        elseif code === :end && buffersize(input) > 0
+            if startproc(codec, :write, error) === :error
+                @goto error
+            end
+        else
+            makemargin!(output, Δout)
+        end
+    end
+    if marginsize(output) == 0
+        return output.data
+    else
+        return output.data[1:output.marginpos-1]
+    end
+    @label error
+    if !haserror(error)
+        set_default_error!(error)
+    end
+    throw(error[])
+end
+
+# Return the initial output buffer size.
+function initial_output_size(codec::Codec, input::Memory)
+    return max(
+        minoutsize(codec, input),
+        expectedsize(codec, input),
+        8,  # just in case where both minoutsize and expectedsize are foolish
+    )
 end


### PR DESCRIPTION
This addresses part of https://github.com/bicycle1885/CodecZstd.jl/issues/13.
```
~/w/TranscodingStreams (master|…) $
julia buffering.zstd.jl; and git co transcode; julia buffering.zstd.jl
 24.045589 seconds (42.10 k allocations: 3.086 GiB, 1.03% gc time)
 23.980275 seconds (1.67 k allocations: 3.084 GiB, 1.70% gc time)
 24.218068 seconds (1.67 k allocations: 3.084 GiB, 1.63% gc time)
 24.023841 seconds (1.67 k allocations: 3.084 GiB, 1.61% gc time)
 24.065087 seconds (1.67 k allocations: 3.084 GiB, 1.65% gc time)
Switched to branch 'transcode'
Your branch is up to date with 'origin/transcode'.
 15.628735 seconds (43.12 k allocations: 7.047 GiB, 1.36% gc time)
 16.158169 seconds (30 allocations: 7.045 GiB, 3.93% gc time)
 15.896305 seconds (30 allocations: 7.045 GiB, 3.88% gc time)
 15.976704 seconds (30 allocations: 7.045 GiB, 3.93% gc time)
 15.972673 seconds (30 allocations: 7.045 GiB, 3.86% gc time)
```